### PR TITLE
Attempt running the test twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Build and Run tests
         run: |
           mkdir $BISECT_DIR
-          dune build @all @runtest --force --instrument-with bisect_ppx
+          dune build @all @runtest
+          dune build @runtest --force --instrument-with bisect_ppx
         env:
           BISECT_DIR: ${{ runner.temp }}/_bisect_ppx_data
           BISECT_FILE: ${{ runner.temp }}/_bisect_ppx_data/data


### PR DESCRIPTION
Pragmatically when running locally I have witnessed that this usually end up resolving the partial coverage report that otherwise gets generated sometimes.

That is an experimental change to try and get going, not a proper fix.